### PR TITLE
Dev

### DIFF
--- a/prisma/migrations/20240903013046_create_history_to_product/migration.sql
+++ b/prisma/migrations/20240903013046_create_history_to_product/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "products" ADD COLUMN     "history" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Product {
   id          String  @id @default(uuid())
   title       String
   description String
+  history     String?
   price       Float   @default(0)
   slug        String  @unique
   isActive    Boolean @default(true)

--- a/src/actions/products/bazar/create-update-product.ts
+++ b/src/actions/products/bazar/create-update-product.ts
@@ -27,14 +27,15 @@ const productSchema = z.object({
   description: z
     .string({
       required_error: 'La descripción es requerida.',
-      message: 'La descripción debe tener entre 30 y 160 caracteres.'
+      message: 'La descripción debe tener entre 150 y 300 caracteres.'
     })
-    .min(10, {
+    .min(150, {
       message: 'La descripción debe tener al menos 10 caracteres.'
     })
-    .max(250, {
+    .max(350, {
       message: 'La descripción debe tener máximo 200 caracteres.'
     }),
+  history: z.string().optional(),
   slug: z
     .string({
       required_error: 'El slug es requerido.',
@@ -74,6 +75,7 @@ const productSchema = z.object({
 
 export const createUpdateProduct = async (formData: FormData) => {
   const data = Object.fromEntries(formData)
+
   const parsedStockDetails = JSON.parse(formData.get('stockDetails') as string)
 
   const dataToValidate = {

--- a/src/app/(shop)/admin/products/page.tsx
+++ b/src/app/(shop)/admin/products/page.tsx
@@ -62,7 +62,7 @@ export default async function ProductsPage({ searchParams }: Props) {
         }
         {
           products.length === 0 && (
-            <div className='flex flex-col w-full items-center justify-center col-span-3 h-36'>
+            <div className='flex flex-col w-full items-center justify-center col-span-4 h-36'>
               <h1>No se han encontrado productos con ese nombre </h1>
               <Link href='/admin/product/create' className='hover:underline'>Crea un producto!</Link>
             </div>

--- a/src/app/(shop)/product/[slug]/page.tsx
+++ b/src/app/(shop)/product/[slug]/page.tsx
@@ -87,7 +87,7 @@ export default async function ProductPage({ params }: Props) {
           </div>
 
           {/* description */}
-          <AccordionDescription description={product.description ? product.description : ''} />
+          <AccordionDescription description={product.description ? product.description : ''} history={product.history ? product.history : ''} />
         </div>
       </div>
 

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -49,7 +49,7 @@ export const Footer = () => {
       <Card className='w-full h-full bg-gray-300 py-5 px-4'>
         <CardTitle className='mb-5'>
           <Link href="/" >
-            <span className={`${titleFont.className} antialiased font-bold`}>Bazar Campechano</span>
+            <span className={`${titleFont.className} antialiased font-bold tracking-wider`}>Bazar Campechano</span>
             <span>© {new Date().getFullYear()}</span>
           </Link>
         </CardTitle>

--- a/src/components/product/accordion-description/AccordionDescription.tsx
+++ b/src/components/product/accordion-description/AccordionDescription.tsx
@@ -8,10 +8,10 @@ import {
 
 interface Props {
   description: string
-  care?: string
+  history?: string
 }
 
-export function AccordionDescription({ description }: Props) {
+export function AccordionDescription({ description, history }: Props) {
   return (
     <Accordion type="single" collapsible defaultValue='item-1' className="w-full">
       <AccordionItem value="item-1">
@@ -20,12 +20,12 @@ export function AccordionDescription({ description }: Props) {
           {description}
         </AccordionContent>
       </AccordionItem>
-      {/* <AccordionItem value="item-2">
-        <AccordionTrigger className='uppercase font-semibold'>Cuidados</AccordionTrigger>
+      <AccordionItem value="item-2">
+        <AccordionTrigger className='uppercase font-semibold'>historia</AccordionTrigger>
         <AccordionContent>
-          {care}
+          {history}
         </AccordionContent>
-      </AccordionItem> */}
+      </AccordionItem>
     </Accordion>
   )
 }

--- a/src/components/product/product-form/ProductForm.tsx
+++ b/src/components/product/product-form/ProductForm.tsx
@@ -97,14 +97,15 @@ const productSchema = z.object({
   description: z
     .string({
       required_error: 'La descripción es requerida.',
-      message: 'La descripción debe tener entre 30 y 250 caracteres.'
+      message: 'La descripción debe tener entre 150 y 300 caracteres.'
     })
-    .min(10, {
-      message: 'La descripción debe tener al menos 10 caracteres.'
+    .min(150, {
+      message: 'La descripción debe tener al menos 150 caracteres.'
     })
-    .max(250, {
-      message: 'La descripción debe tener máximo 250 caracteres.'
+    .max(350, {
+      message: 'La descripción debe tener máximo 300 caracteres.'
     }),
+  history: z.string().optional(),
   slug: z
     .string({
       required_error: 'El slug es requerido.',
@@ -159,6 +160,7 @@ export const ProductForm = ({ product, categories }: Props) => {
     title: product?.title,
     slug: product?.slug,
     description: product?.description || '',
+    history: product?.history || '',
     price: product?.price || 0,
     categoryId,
     productImage: undefined
@@ -206,6 +208,7 @@ export const ProductForm = ({ product, categories }: Props) => {
     formData.append('price', productToSave.price.toString())
     formData.append('categoryId', productToSave.categoryId)
     formData.append('stockDetails', JSON.stringify(stockDetails))
+    formData.append('history', productToSave.history || '')
     formData.append('categoryName', categoryName as string)
 
     if (productImage) {
@@ -373,6 +376,23 @@ export const ProductForm = ({ product, categories }: Props) => {
                   <FormLabel>Descripción</FormLabel>
                   <FormControl>
                     <Textarea placeholder='Descripción del producto' {...field} value={field.value ?? ''} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+
+          {/* history */}
+          <CardContent>
+            <FormField
+              control={form.control}
+              name='history'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Historia</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder='Historia del producto' {...field} value={field.value ?? ''} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/interfaces/product/product.interface.ts
+++ b/src/interfaces/product/product.interface.ts
@@ -2,6 +2,7 @@ export interface Product {
   id: string
   title: string
   description: string | null
+  history: string | null
   price: number
   slug: string
   productImage: ProductImage[]
@@ -14,6 +15,7 @@ export interface ProductCreateUpdate {
   id?: string
   title: string
   description: string | null
+  history: string | null
   price: number
   slug: string
   categoryId: string


### PR DESCRIPTION
feat: :sparkles: Add history field to product model and form

- Added a new `history` field to the `Product` model in Prisma schema.
- Updated validation rules for `description` in the product form.
- Modified product-related components to include and display `history`.
- Adjusted layout and styles in the product pages and footer.

This change enhances the product information with a history field, allowing better tracking and presentation of product details. Also, the validation rules for `description` have been updated to ensure more meaningful content.