### PR TITLE
feat: :sparkles: enable multi-image upload and native share button

### DIFF
--- a/src/app/(shop)/product/[slug]/page.tsx
+++ b/src/app/(shop)/product/[slug]/page.tsx
@@ -66,7 +66,6 @@ export default async function ProductPage({ params }: Props) {
   const { slug } = params
   const { products } = await getPaginationProducts({ page: 1 })
   const product = await getProductBySlug(slug)
-
   if (!product) {
     notFound()
   }
@@ -102,7 +101,7 @@ export default async function ProductPage({ params }: Props) {
 
           <ButtonBack className='text-gray-500 hover:no-underline hover:text-gray-900 text-xl min-[960px]:flex gap-1 pl-0' name='VOLVER' icon={<IoArrowBackOutline />} />
 
-          <ButtonShare className='fixed bottom-10 z-10 right-16 text-black hover:no-underline hover:text-gray-900 text-xl flex gap-1 p-2 rounded-none border-black border bg-white h-12 w-12' icon={<IoShareSocialOutline size={25} />} />
+          <ButtonShare className='fixed bottom-10 z-10 right-16 text-black hover:no-underline hover:text-gray-900 text-xl flex gap-1 p-2 rounded-none border-black border bg-white h-12 w-12' icon={<IoShareSocialOutline size={25} />} title={product.title} description={product.description || ''} />
 
           <div className='flex gap-2 justify-between'>
             <h2 className={`${titleFont.className} antialiased font-bold text-2xl uppercase`}>

--- a/src/components/product/buttons/ButtonShare.tsx
+++ b/src/components/product/buttons/ButtonShare.tsx
@@ -4,8 +4,8 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 
-const noticeCopyLinkProduct = () => {
-  toast('Link copiado al portapapeles', {
+const noticeShareProduct = () => {
+  toast.success('Producto compartido', {
     position: 'top-right',
     duration: 2000
   })
@@ -15,9 +15,11 @@ interface Props {
   name?: string
   icon?: JSX.Element
   className?: string
+  title: string
+  description: string
 }
 
-export const ButtonShare = ({ className, icon, name }: Props) => {
+export const ButtonShare = ({ className, icon, name, description, title }: Props) => {
   const [isVisible, setIsVisible] = useState(false)
   const fixedScrollThreshold = 2 // 2% scroll threshold
 
@@ -42,8 +44,14 @@ export const ButtonShare = ({ className, icon, name }: Props) => {
           variant='outline'
           className={className}
           onClick={() => {
-            navigator.clipboard.writeText(window.location.href)
-            noticeCopyLinkProduct()
+            if (navigator.share) {
+              navigator.share({
+                title,
+                text: description,
+                url: window.location.href
+              })
+                .then(() => { noticeShareProduct() })
+            }
           }}
         >
           {icon}

--- a/src/components/product/cloudinary-button/CloudinaryButton.tsx
+++ b/src/components/product/cloudinary-button/CloudinaryButton.tsx
@@ -14,7 +14,7 @@ interface IUploaderProps {
 const uploadPreset = process.env.NEXT_PUBLIC_CLOUDINARY_UPLOAD_PRESET
 
 export function CloudinaryButton({ images, setImages }: IUploaderProps) {
-  const isImageComplete = images.length >= 4
+  // const isImageComplete = images.length >= 4
 
   function handleSuccess(result: CloudinaryUploadWidgetResults) {
     if (!result.info || typeof result.info === 'string') {
@@ -42,36 +42,32 @@ export function CloudinaryButton({ images, setImages }: IUploaderProps) {
   return (
     <div>
       <div className='w-full flex-col-reverse flex items-center justify-between gap-3'>
-        <p className='text-[10px]'>Puedes subir hasta 4 imágenes por producto</p>
-        {
-          !isImageComplete && (
-            <CldUploadWidget
-              uploadPreset={uploadPreset}
-              options={{
-                sources: ['local', 'url', 'camera', 'image_search'],
-                showSkipCropButton: false,
-                cropping: true,
-                croppingAspectRatio: 1,
-                clientAllowedFormats: ['png', 'jpeg', 'jpg']
+        <p className='text-[10px]'>Se recomienda subir hasta 4 imágenes por producto</p>
+        <CldUploadWidget
+          uploadPreset={uploadPreset}
+          options={{
+            sources: ['local', 'camera', 'image_search'],
+            // showSkipCropButton: false,
+            // cropping: true,
+            // croppingAspectRatio: 1,
+            clientAllowedFormats: ['png', 'jpeg', 'jpg']
+          }}
+          onError={handleError}
+          onSuccess={handleSuccess}
+        >
+          {({ widget, cloudinary, open }) => (
+            <Button
+              className="me-2 inline-flex items-center rounded-none bg-black px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-black/80 focus:outline-none focus:ring-4"
+              type='button'
+              onClick={() => {
+                open()
               }}
-              onError={handleError}
-              onSuccess={handleSuccess}
             >
-              {({ widget, cloudinary, open }) => (
-                <Button
-                  className="me-2 inline-flex items-center rounded-none bg-black px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-black/80 focus:outline-none focus:ring-4"
-                  type='button'
-                  onClick={() => {
-                    open()
-                  }}
-                >
-                  <IoCloudDoneOutline className="mr-2" />
-                  Subir imagen
-                </Button>
-              )}
-            </CldUploadWidget>
-          )
-        }
+              <IoCloudDoneOutline className="mr-2" />
+              Subir imagen
+            </Button>
+          )}
+        </CldUploadWidget>
       </div>
     </div>
   )


### PR DESCRIPTION
- Updated the product page to allow uploading multiple images without cropping and removed the 4-image limit.
- Modified the Share button to use the Web Share API, allowing users to share the product via the native sharing options of the browser instead of copying the URL to the clipboard.
- Enhanced the user experience by providing a more flexible image upload process and native sharing dialog.