### PR TITLE
fix: :art: Repair styles for responsive layout

### DIFF
--- a/src/app/(shop)/page.tsx
+++ b/src/app/(shop)/page.tsx
@@ -39,7 +39,7 @@ export default async function ShopPage({ searchParams }: Props) {
         <TitleHome
           title="De segunda mano"
           subtitle="Rebajas"
-          className='text-center uppercase pt-10'
+          className='text-center uppercase pt-10 mb-14'
         />
         <CurrentProductsGrid products={products} />
         <Button asChild variant='outline' className='flex justify-center mx-auto w-3/4 max-w-32 uppercase bg-transparent mt-[52px]'>
@@ -67,7 +67,7 @@ export default async function ShopPage({ searchParams }: Props) {
         <TitleHome
           title="Calzado de bazar"
           subtitle="precios justos"
-          className='text-center uppercase text-white pt-10'
+          className='text-center uppercase text-white pt-10 mb-14'
         />
         <NewProductsGrid products={shoeProducts} />
         <Button asChild variant='outline' className='flex justify-center mx-auto w-3/4 max-w-32 uppercase bg-transparent text-white mt-[52px]'>
@@ -81,7 +81,7 @@ export default async function ShopPage({ searchParams }: Props) {
         <TitleHome
           title="Los más divertido"
           subtitle="Juguetes"
-          className='text-center uppercase text-white pt-10'
+          className='text-center uppercase text-white pt-10 mb-14'
         />
         <NewProductsGrid products={toyProducts} />
         <Button asChild variant='outline' className='flex justify-center mx-auto w-3/4 max-w-32 uppercase bg-transparent mt-[52px] text-white'>

--- a/src/components/ui/title-home/TitleHome.tsx
+++ b/src/components/ui/title-home/TitleHome.tsx
@@ -9,9 +9,9 @@ interface TitleProps {
 export const TitleHome = ({ title, subtitle, className }: TitleProps) => {
   return (
     <div className={`px-3 mb-4 ${className}`}>
-      <h1 className={`${titleFont.className} text-[40px] antialiased`}>{title}</h1>
+      <h1 className={`${titleFont.className} text-4xl sm:text-[40px] antialiased`}>{title}</h1>
       {subtitle && (
-        <h3 className="-mt-7 text-[56px] font-black">{subtitle}</h3>
+        <h3 className="-mt-2 sm:-mt-7 text-5xl sm:text-[56px] font-black">{subtitle}</h3>
       )}
     </div>
   )


### PR DESCRIPTION
- Fixed styles in `ShopPage` by adding margin-bottom (`mb-14`) to titles, improving spacing in responsive view.
- Updated font sizes and margins in the `TitleHome` component to ensure they display correctly on different screen sizes:
  - Set `h1` to use `text-4xl` for smaller screens and `sm:text-[40px]` for larger screens.
  - Adjusted `h3` margins and sizes to range from `text-5xl` to `sm:text-[56px]`.

These changes ensure a stable and visually appealing layout across all devices.