### PR TITLE
style 🎨 adjust margins and spacing in components

### DIFF
--- a/src/app/(shop)/page.tsx
+++ b/src/app/(shop)/page.tsx
@@ -39,7 +39,7 @@ export default async function ShopPage({ searchParams }: Props) {
         <TitleHome
           title="De segunda mano"
           subtitle="Rebajas"
-          className='text-center uppercase pt-10 mb-14'
+          className='text-center uppercase pt-10'
         />
         <CurrentProductsGrid products={products} />
         <Button asChild variant='outline' className='flex justify-center mx-auto w-3/4 max-w-32 uppercase bg-transparent mt-[52px]'>

--- a/src/components/products/product-grid/CurrentProductsGrid.tsx
+++ b/src/components/products/product-grid/CurrentProductsGrid.tsx
@@ -50,7 +50,7 @@ export const CurrentProductsGrid = ({ products }: Props) => {
   }, [products])
   return (
     <>
-      <div className="relative w-full">
+      <div className="relative w-full mt-14">
         <Button onClick={scrollLeft} disabled={isLeftDisabled} className="absolute left-2 -top-7 transform -translate-y-1/2 px-3 pr-2">
           <MdArrowBackIos className='w-5 h-5' />
         </Button>

--- a/src/components/products/product-grid/NewProductsGrid.tsx
+++ b/src/components/products/product-grid/NewProductsGrid.tsx
@@ -50,7 +50,7 @@ export const NewProductsGrid = ({ products }: Props) => {
   }, [products])
   return (
 
-    <div className="relative w-full">
+    <div className="relative w-full mt-14">
       <Button onClick={scrollLeft} disabled={isLeftDisabled} className="absolute left-2 -top-7 transform -translate-y-1/2 px-3 pr-2">
         <MdArrowBackIos className='w-5 h-5' />
       </Button>

--- a/src/components/ui/title-home/TitleHome.tsx
+++ b/src/components/ui/title-home/TitleHome.tsx
@@ -11,7 +11,7 @@ export const TitleHome = ({ title, subtitle, className }: TitleProps) => {
     <div className={`px-3 mb-4 ${className}`}>
       <h1 className={`${titleFont.className} text-4xl sm:text-[40px] antialiased`}>{title}</h1>
       {subtitle && (
-        <h3 className="-mt-2 sm:-mt-7 text-5xl sm:text-[56px] font-black">{subtitle}</h3>
+        <h3 className="-mt-2 text-5xl sm:text-[56px] font-black">{subtitle}</h3>
       )}
     </div>
   )


### PR DESCRIPTION
- Removed bottom margin in `TitleHome` within `ShopPage`.
- Added top margin (`mt-14`) in `CurrentProductsGrid` and `NewProductsGrid` containers.
- Simplified styles in the `TitleHome` component for better visual consistency.