### PR TITLE
feat :iphone: :desktop_computer: Adjust category menu for mobile and …

### DIFF
--- a/src/app/(shop)/admin/layout.tsx
+++ b/src/app/(shop)/admin/layout.tsx
@@ -13,7 +13,7 @@ export default async function AdminLayout({
   }
 
   return (
-    <div className='px-1 pt-10 mt-[104.67px] md:p-4 min-[992px]:p-6 min-[1200px]:p-10 pb-10'>
+    <div className='px-1 pt-10 mt-[104.67px] sm:mt-[60.67px] md:p-4 min-[992px]:p-6 min-[1200px]:p-10 pb-10'>
       {children}
     </div>
   )

--- a/src/app/(shop)/cart/page.tsx
+++ b/src/app/(shop)/cart/page.tsx
@@ -10,7 +10,7 @@ export default async function CartPage() {
   const { products } = await getPaginationProducts({ page: 1 })
   return (
     <>
-      <div className='mt-[104.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
+      <div className='mt-[104.67px] sm:mt-[60.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
         <Title title='Carrito' subtitle="Tus compras en el carrito" />
         <div className="flex justify-start items-center mb-20 px-1 sm:px-0">
 

--- a/src/app/(shop)/category/[category]/page.tsx
+++ b/src/app/(shop)/category/[category]/page.tsx
@@ -55,7 +55,7 @@ export default async function CategoryByPage({ params, searchParams }: Props) {
   const { products, totalPages } = result
 
   return (
-    <div className='mt-[104.67px] pt-10'>
+    <div className='mt-[104.67px] sm:mt-[60.67px] pt-10'>
       <div className='flex justify-between mb-6 gap-2'>
         <ProductSearch placeholder='Buscar producto...' />
 

--- a/src/app/(shop)/checkout/layout.tsx
+++ b/src/app/(shop)/checkout/layout.tsx
@@ -12,7 +12,7 @@ export default async function CheckoutLayout({
     redirect('/auth/login?redirectTo=/checkout/shipping-method')
   }
   return (
-    <div className='mt-[104.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
+    <div className='mt-[104.67px] sm:mt-[60.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
       {
         children
       }

--- a/src/app/(shop)/empty/page.tsx
+++ b/src/app/(shop)/empty/page.tsx
@@ -4,7 +4,7 @@ import { IoCartOutline } from 'react-icons/io5'
 export default async function EmptyPage() {
   return (
     <>
-      <div className='flex justify-center items-center h-[400px] mt-[104.67px] pt-10' >
+      <div className='flex justify-center items-center h-[400px] mt-[104.67px] sm:mt-[60.67px] pt-10' >
         <IoCartOutline size={90} className="mx-5" />
 
         <div>

--- a/src/app/(shop)/info/layout.tsx
+++ b/src/app/(shop)/info/layout.tsx
@@ -13,7 +13,7 @@ export default async function AdminLayout({
   }
 
   return (
-    <div className='px-1 pt-10 mt-[104.67px] md:p-4 min-[992px]:p-6 min-[1200px]:p-10 pb-10'>
+    <div className='px-1 pt-10 mt-[104.67px] sm:mt-[60.67px] md:p-4 min-[992px]:p-6 min-[1200px]:p-10 pb-10'>
       {children}
     </div>
   )

--- a/src/app/(shop)/orders/layout.tsx
+++ b/src/app/(shop)/orders/layout.tsx
@@ -4,7 +4,7 @@ export default async function OrdersLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className='mt-[104.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
+    <div className='mt-[104.67px] sm:mt-[60.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
       {
         children
       }

--- a/src/app/(shop)/product/[slug]/page.tsx
+++ b/src/app/(shop)/product/[slug]/page.tsx
@@ -72,7 +72,7 @@ export default async function ProductPage({ params }: Props) {
 
   return (
     <>
-      <div className='mb-20 mt-[104.67px] min-[960px]:pt-6 min-[960px]:mx-6 grid min-[960px]:grid-cols-3 gap-3'>
+      <div className='mb-20 mt-[104.67px] sm:mt-[60.67px] min-[960px]:pt-6 min-[960px]:mx-6 grid min-[960px]:grid-cols-3 gap-3'>
 
         {/* mobile */}
         <div className='min-[960px]:hidden relative'>

--- a/src/app/(shop)/products/layout.tsx
+++ b/src/app/(shop)/products/layout.tsx
@@ -4,7 +4,7 @@ export default function ProductsLayout({
   children: React.ReactNode
 }>) {
   return (
-    <div className="mt-[104.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20">
+    <div className="mt-[104.67px] sm:mt-[60.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20">
       {children}
     </div>
   )

--- a/src/app/(shop)/profile/layout.tsx
+++ b/src/app/(shop)/profile/layout.tsx
@@ -4,7 +4,7 @@ export default async function ProfileLayout({
   children: React.ReactNode
 }>) {
   return (
-    <div className='mt-[104.67px]  pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
+    <div className='mt-[104.67px] sm:mt-[60.67px] pt-10 px-1 sm:px-5 md:px-10 lg:px-14 xl:px-20'>
       {children}
     </div>
   )

--- a/src/components/ui/header/HeaderHero.tsx
+++ b/src/components/ui/header/HeaderHero.tsx
@@ -6,7 +6,7 @@ import { titleFont } from '@/config/fonts'
 export const HeaderHero = () => {
   return (
     <>
-      <header className="w-full pt-[104.67px] bg-slate-300"></header>
+      <header className="w-full pt-[104.67px] sm:pt-[60.67px] bg-slate-300"></header>
       <Image src={hero} alt="hero image" className="object-cover h-[480px]" />
       {/* main container */}
       <div className="w-full overflow-hidden bg-[#0E0F0F]">


### PR DESCRIPTION
…desktop

Updated top margin across layouts to properly display the category menu on both mobile and desktop versions. Adjusted margins to ensure consistent spacing and alignment for different screen sizes.

- Updated `mt-[104.67px]` with `sm:mt-[60.67px]` across various layout files to ensure correct margin for mobile and desktop views.
- Adjusted `HeaderHero` component with `sm:pt-[60.67px]` for better spacing on smaller screens.
- Modified layouts (`admin`, `cart`, `checkout`, `products`, etc.) for consistent display and spacing across devices.