### PR TITLE
refactor :fire: remove admin validation from shop info layout

### DIFF
--- a/src/app/(shop)/info/layout.tsx
+++ b/src/app/(shop)/info/layout.tsx
@@ -1,17 +1,8 @@
-import { redirect } from 'next/navigation'
-import { validateUserAdmin } from '@/actions'
-
 export default async function AdminLayout({
   children
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const isAdmin = await validateUserAdmin()
-
-  if (!isAdmin) {
-    redirect('/profile')
-  }
-
   return (
     <div className='px-1 pt-10 mt-[104.67px] sm:mt-[60.67px] md:p-4 min-[992px]:p-6 min-[1200px]:p-10 pb-10'>
       {children}


### PR DESCRIPTION
Removed the `validateU
serAdmin` function and redirection logic from the `info/layout.tsx` file in the shop app. This change simplifies the layout component by removing the administrative validation and redirection.

- Removed `validateUserAdmin` call and related imports.
- Deleted conditional redirection to the `/profile` page for non-admin users.