### PR TITLE
fix: :bug: Ensure only active products are retrieved in queries

### DIFF
--- a/src/actions/products/get-featured-products.ts
+++ b/src/actions/products/get-featured-products.ts
@@ -90,9 +90,14 @@ export const getFeaturedProducts = async ({ page = 1, take = 12, query = '', cat
 
     const totalCount = await prisma.product.count({
       where: {
-        category: {
-          name: category
-        },
+        isActive: true,
+        ...(category
+          ? {
+              category: {
+                name: category
+              }
+            }
+          : {}),
         OR: [
           {
             title: {

--- a/src/actions/products/get-products.ts
+++ b/src/actions/products/get-products.ts
@@ -90,9 +90,14 @@ export const getProducts = async ({ page = 1, take = 12, query = '', category }:
 
     const totalCount = await prisma.product.count({
       where: {
-        category: {
-          name: category
-        },
+        isActive: true,
+        ...(category
+          ? {
+              category: {
+                name: category
+              }
+            }
+          : {}),
         OR: [
           {
             title: {


### PR DESCRIPTION
Updated product retrieval logic to include an `isActive` filter, ensuring only active products are counted and displayed in featured and general product queries.

Changes include:
- Added `isActive: true` to the product filtering conditions in `getFeaturedProducts` and `getProducts`.
- Made category filtering optional, improving flexibility in queries.